### PR TITLE
Fix build script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "build": "BABEL_ENV=production ./node_modules/.bin/webpack --config webpack.config.production.js",
+    "build": "./node_modules/.bin/cross-env BABEL_ENV=production ./node_modules/.bin/webpack --config webpack.config.production.js",
     "lint": "./node_modules/.bin/eslint ."
   },
   "repository": {
@@ -38,6 +38,7 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "cross-env": "^3.1.1",
     "eslint": "^0.21.2",
     "eslint-plugin-react": "^2.3.0",
     "react-transform-hmr": "^1.0.1",


### PR DESCRIPTION
Without cross-env it shows this error

> 'BABEL_ENV' is not recognized as an internal or external command, operable program or batch file.
